### PR TITLE
Fix type error

### DIFF
--- a/src/Testing/ExtendsAssertions.php
+++ b/src/Testing/ExtendsAssertions.php
@@ -22,7 +22,7 @@ trait ExtendsAssertions
      * @param null $message
      * @return void
      */
-    function assertArrayEquals(iterable $expected, iterable $actual, $message = null)
+    function assertArrayEquals(iterable $expected, iterable $actual, $message = '')
     {
         if ($expected instanceof Collection) {
             $expected = $expected->toArray();
@@ -48,7 +48,7 @@ trait ExtendsAssertions
      * @param null $message
      * @return void
      */
-    function assertArrayNotEquals(Array $expected, Array $actual, $message = null)
+    function assertArrayNotEquals(Array $expected, Array $actual, $message = '')
     {
         if ($expected instanceof Collection) {
             $expected = $expected->toArray();


### PR DESCRIPTION
TypeError: Argument 3 passed to PHPUnit\Framework\Assert::assertEquals() must be of the type string, null given, called in ...